### PR TITLE
Remove RandomWebBrowse from the suite, fix for ip_link

### DIFF
--- a/tests/ip_link.py
+++ b/tests/ip_link.py
@@ -27,4 +27,4 @@ class InterfacesShow(rootfs_boot.RootFSBootTest):
         else:
             msg = "0 interfaces are UP."
         self.result_message = msg
-        assert num_up >= 2
+        assert num_up >= 1

--- a/tests/webbrowse.py
+++ b/tests/webbrowse.py
@@ -52,6 +52,7 @@ class RandomWebBrowse(rootfs_boot.RootFSBootTest):
                 lan.expect('Downloaded:', timeout=20)
             except Exception:
                 lan.sendcontrol('c')
+                raise
             lan.expect(prompt)
             lan.sendline("rm -rf /tmp/webbrowse-test")
             lan.expect(prompt)

--- a/testsuites.cfg
+++ b/testsuites.cfg
@@ -19,7 +19,6 @@ DhcpLeaseCheck
 IfconfigCheck
 UciShowWireless
 ProcVmstat
-RandomWebBrowse
 Webserver_Running
 WebGUI_Access
 WebGUI_NoStackTrace


### PR DESCRIPTION
RandomWebBrowse has always been passing due to the fact that a failure has never been raised, this PR fixes that and removes it from the testsuite since the test is too unreliable.

The ip_link change is needed since with just eth0 and loopback available we should get one UNKNOWN and one DOWN state, rather than UP & DOWN as the test would expect.