### PR TITLE
Junit XML classname fix

### DIFF
--- a/tests/linux_boot.py
+++ b/tests/linux_boot.py
@@ -23,7 +23,7 @@ class LinuxBootTest(unittest2.TestCase):
         self.logged = dict()
 
     def id(self):
-        return self.__class__.__name__
+        return "boardfarm." + self.__class__.__name__ + "()"
 
     def setUp(self):
         lib.common.test_msg("\n==================== Begin %s ====================" % self.__class__.__name__)


### PR DESCRIPTION
The Junit parser requires at least one dot to be present in a test's returned ID and parentheses at the end of the classname, this brings all of the tests' classnames in line with that requirement.

For reference:
http://bazaar.launchpad.net/~testtools-committers/pyjunitxml/trunk/view/head:/junitxml/__init__.py#L149

This closes CreatorDev/openwrt#158