### PR TITLE
Boardfarm ping6 test from ci40 to a clicker

### DIFF
--- a/tests/ping6_clicker.py
+++ b/tests/ping6_clicker.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2017
+#
+# All rights reserved.
+#
+# This file is distributed under the Clear BSD license.
+# The full text can be found in LICENSE in the root directory.
+import os
+import rootfs_boot
+from devices import board
+
+class BoardPing6ClickerDev(rootfs_boot.RootFSBootTest):
+	'''Board lowpan interface can ping6 the clicker.'''
+	def runTest(self):
+		CLICKER_IP=os.getenv('CLICKER1_IP')
+		board.sendline('\nping6 -I lowpan0 -c 20 -s 80 {}\n'.format(CLICKER_IP))
+		board.expect('PING ')
+		board.expect(' ([0-9]+) packets received')
+		board.expect(' ([0-1]+)% packet loss')
+		n = int(board.match.group(1))
+		board.expect(prompt)
+		assert n > 0

--- a/testsuites.cfg
+++ b/testsuites.cfg
@@ -32,6 +32,7 @@ LanDevPingRouter
 OpkgUpdate
 OpkgInstall
 OpkgRemove
+BoardPing6ClickerDev
 
 [ci40_failed_in_test_suite]
 Set_IPv6_Addresses


### PR DESCRIPTION
This test will ping6 20 packets from the ci40 board to a clicker
using 6lowpan wireless interface

connects CreatorDev/boardfarm#3
Signed-off-by: Tushar Jobanputra <tushar.jobanputra@imgtec.com>